### PR TITLE
Improve dashboard UI with sidebar and theme switch

### DIFF
--- a/src/main/resources/static/css/components/button.css
+++ b/src/main/resources/static/css/components/button.css
@@ -1,7 +1,7 @@
 .button {
     display: inline-block;
     padding: 12px 24px;
-    background: #6200ea;
+    background: var(--primary-color);
     color: white;
     text-decoration: none;
     font-size: 16px;
@@ -12,7 +12,7 @@
 }
 
 .button:hover {
-    background: #3700b3;
+    background: var(--accent-color);
 }
 
 .button:active {

--- a/src/main/resources/static/css/components/navigation.css
+++ b/src/main/resources/static/css/components/navigation.css
@@ -1,78 +1,56 @@
-.navbar {
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background: #1e1e1e;
+.sidebar {
+    width: var(--sidebar-width);
+    min-height: 100vh;
+    background: var(--surface-color);
     position: fixed;
-    padding: 15px 20px;
-    z-index: 1000;
     top: 0;
     left: 0;
+    padding: 24px 16px;
+    box-shadow: 2px 0 8px rgba(0,0,0,0.2);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
 }
 
-.navbar .logo {
+.sidebar .logo {
     font-size: 24px;
     font-weight: bold;
-    color: #bb86fc;
+    color: var(--accent-color);
     text-decoration: none;
+    margin-bottom: 8px;
 }
 
-.nav-links {
-    list-style: none;
+.sidebar-nav {
     display: flex;
-    gap: 20px;
+    flex-direction: column;
+    gap: 8px;
+    list-style: none;
 }
 
-.nav-links li {
-    display: inline;
-}
-
-.nav-links a {
-    color: #e0e0e0;
+.sidebar-nav a,
+#themeToggle {
+    padding: 10px;
+    border-radius: 4px;
+    color: var(--text-color);
     text-decoration: none;
-    transition: color 0.3s;
+    background: transparent;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+    transition: background 0.2s;
 }
 
-.nav-links a:hover {
-    color: #bb86fc;
+.sidebar-nav a:hover,
+#themeToggle:hover {
+    background: var(--surface-elevated);
 }
 
 .signout {
-    color: #ff5555 !important;
-    font-weight: bold;
+    color: var(--danger-color);
 }
 
-.signout:hover {
-    color: #ff7777 !important;
-}
-
-.menu-toggle {
-    display: none;
-    font-size: 24px;
-    background: none;
-    color: white;
-    border: none;
-    cursor: pointer;
-}
-
-@media (max-width: 786px) {
-    .nav-links {
-        display: none;
-        flex-direction: column;
-        position: absolute;
-        top: 60px;
-        right: 0;
-        background: #1e1e1e;
-        width: 200px;
-        padding: 10px;
-    }
-
-    .nav-links.active {
-        display: flex;
-    }
-
-    .menu-toggle {
-        display: block;
-    }
+.main-content {
+    margin-left: var(--sidebar-width);
+    padding: 20px;
+    width: calc(100% - var(--sidebar-width));
 }

--- a/src/main/resources/static/css/components/quiz-item.css
+++ b/src/main/resources/static/css/components/quiz-item.css
@@ -1,10 +1,10 @@
 .quiz-item {
-    background: #1e1e1e;
+    background: var(--surface-color);
     border-radius: 8px;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    border-left: 5px solid #bb86fc;
+    border-left: 5px solid var(--accent-color);
     transition: transform 0.2s;
     text-align: left;
     cursor: pointer;
@@ -17,7 +17,7 @@
 .quiz-item.creating {
     pointer-events: none;
     opacity: 0.5;
-    background: #2a2a2a;
+    background: var(--surface-elevated);
     border-left: 5px solid #ff9800;
 }
 
@@ -31,7 +31,7 @@
 
 .quiz-details p {
     font-size: clamp(12px, 2.5vw, 14px);
-    color: #b0b0b0;
+    color: var(--text-secondary-color);
 }
 
 .quiz-link {

--- a/src/main/resources/static/css/pages/auth.css
+++ b/src/main/resources/static/css/pages/auth.css
@@ -12,7 +12,7 @@
     width: 400px;
     max-width: 100%;
     padding: 30px 16px 30px 16px;
-    background: #1e1e1e;
+    background: var(--surface-color);
     border-radius: 10px;
     box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.4);
 }
@@ -33,15 +33,15 @@
     width: 100%;
     padding: 12px;
     border-radius: 5px;
-    border: 1px solid #333;
-    background: #2a2a2a;
-    color: #e0e0e0;
+    border: 1px solid var(--surface-elevated);
+    background: var(--surface-elevated);
+    color: var(--text-color);
     margin-bottom: 8px;
 }
 
 .input-group input:focus {
     outline: none;
-    border-color: #bb86fc;
+    border-color: var(--accent-color);
     box-shadow: 0px 0px 8px rgba(187, 134, 252, 0.5);
 }
 
@@ -56,7 +56,7 @@ p {
 }
 
 p a {
-    color: #bb86fc;
+    color: var(--accent-color);
     text-decoration: none;
 }
 

--- a/src/main/resources/static/css/pages/create-quiz.css
+++ b/src/main/resources/static/css/pages/create-quiz.css
@@ -12,7 +12,7 @@
     width: 400px;
     max-width: 100%;
     padding: 30px;
-    background: #1e1e1e;
+    background: var(--surface-color);
     border-radius: 10px;
     box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.4);
 }
@@ -32,15 +32,15 @@
 .input-group label {
     font-size: 14px;
     margin-bottom: 5px;
-    color: #b0b0b0;
+    color: var(--text-secondary-color);
 }
 
 .input-group select {
     padding: 12px;
     border-radius: 5px;
-    border: 1px solid #333;
-    background: #2a2a2a;
-    color: #e0e0e0;
+    border: 1px solid var(--surface-elevated);
+    background: var(--surface-elevated);
+    color: var(--text-color);
 }
 
 .input-group textarea {
@@ -49,9 +49,9 @@
     padding: 12px;
     font-size: 18px;
     border-radius: 8px;
-    border: 1px solid #333;
-    background: #2a2a2a;
-    color: #e0e0e0;
+    border: 1px solid var(--surface-elevated);
+    background: var(--surface-elevated);
+    color: var(--text-color);
     resize: none;
 }
 
@@ -65,7 +65,7 @@
 .radio-group label {
     display: flex;
     align-items: center;
-    background: #2a2a2a;
+    background: var(--surface-elevated);
     padding: 8px 12px;
     border-radius: 5px;
     cursor: pointer;
@@ -78,11 +78,11 @@
 }
 
 .radio-group label:hover {
-    background: #373737;
+    background: var(--surface-color);
 }
 
 .radio-group input:checked+label {
-    background: #bb86fc;
+    background: var(--accent-color);
     color: white;
 }
 
@@ -90,7 +90,7 @@
 .input-group textarea:focus,
 .input-group select:focus {
     outline: none;
-    border-color: #bb86fc;
+    border-color: var(--accent-color);
     box-shadow: 0px 0px 8px rgba(187, 134, 252, 0.5);
 }
 

--- a/src/main/resources/static/css/pages/dashboard.css
+++ b/src/main/resources/static/css/pages/dashboard.css
@@ -1,7 +1,7 @@
 .dashboard-container {
-    margin-top: 80px;
-    width: 100vw;
+    width: 100%;
     max-width: 800px;
+    margin: 0 auto;
     text-align: center;
     padding-bottom: 50px;
 }

--- a/src/main/resources/static/css/pages/home.css
+++ b/src/main/resources/static/css/pages/home.css
@@ -11,7 +11,7 @@
     max-width: 600px;
     padding: 40px;
     text-align: center;
-    background: #1e1e1e;
+    background: var(--surface-color);
     border-radius: 12px;
     box-shadow: 0px 8px 20px rgba(0, 0, 0, 0.3);
 }
@@ -27,7 +27,7 @@
 }
 
 .highlight {
-    color: #bb86fc;
+    color: var(--accent-color);
     text-shadow: 0px 0px 8px rgba(187, 134, 252, 0.6);
 }
 

--- a/src/main/resources/static/css/pages/questions.css
+++ b/src/main/resources/static/css/pages/questions.css
@@ -1,7 +1,7 @@
 .quiz-container {
-    margin-top: 80px;
-    width: 100vw;
+    width: 100%;
     max-width: 800px;
+    margin: 0 auto;
     text-align: center;
     padding-bottom: 50px;
 }
@@ -12,7 +12,7 @@ h1 {
 }
 
 .question {
-    background: #1e1e1e;
+    background: var(--surface-color);
     padding: 15px;
     border-radius: 8px;
     margin-bottom: 15px;
@@ -33,7 +33,7 @@ h1 {
 .options label {
     display: flex;
     align-items: center;
-    background: #2a2a2a;
+    background: var(--surface-elevated);
     padding: 10px;
     border-radius: 5px;
     cursor: pointer;
@@ -46,11 +46,11 @@ h1 {
 }
 
 .options label:hover {
-    background: #373737;
+    background: var(--surface-color);
 }
 
 .options input:checked+label {
-    background: #bb86fc;
+    background: var(--accent-color);
     color: white;
 }
 
@@ -63,7 +63,7 @@ h1 {
 }
 
 .delete-quiz {
-    background: #cc4444;
+    background: var(--danger-color);
     display: inline-block;
     padding: 12px 24px;
     color: white;
@@ -84,7 +84,7 @@ h1 {
 }
 
 .incorrect {
-    border: 2px solid #ff5555;
+    border: 2px solid var(--danger-color);
 }
 
 .options input[disabled]+span {

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -8,6 +8,26 @@
 @import url("pages/create-quiz.css");
 @import url("pages/questions.css");
 
+:root {
+    --sidebar-width: 220px;
+    --bg-color: #121212;
+    --surface-color: #1e1e1e;
+    --surface-elevated: #2a2a2a;
+    --text-color: #e0e0e0;
+    --text-secondary-color: #b0b0b0;
+    --primary-color: #6200ea;
+    --accent-color: #bb86fc;
+    --danger-color: #ff5555;
+}
+
+body.light {
+    --bg-color: #fafafa;
+    --surface-color: #ffffff;
+    --surface-elevated: #f0f0f0;
+    --text-color: #333333;
+    --text-secondary-color: #666666;
+}
+
 * {
     margin: 0;
     padding: 0;
@@ -26,8 +46,8 @@ body {
     flex-direction: column;
     align-items: center;
     line-height: 1.6;
-    background: #121212;
-    color: #e0e0e0;
+    background: var(--bg-color);
+    color: var(--text-color);
     opacity: 0;
     animation: fadeIn 0.8s ease-in-out forwards;
     overflow-x: hidden;
@@ -50,10 +70,10 @@ body {
 }
 
 ::-webkit-scrollbar-track {
-    background: #222;
+    background: var(--surface-color);
 }
 
 ::-webkit-scrollbar-thumb {
-    background: #bb86fc;
+    background: var(--accent-color);
     border-radius: 4px;
 }

--- a/src/main/resources/static/js/script.js
+++ b/src/main/resources/static/js/script.js
@@ -1,13 +1,17 @@
-document.addEventListener("DOMContentLoaded", () => {
-    const menuToggle = document.getElementById("menuToggle");
-    const navLinks = document.getElementById("navLinks");
-
-    if(menuToggle) {
-        menuToggle.addEventListener("click", () => {
-            navLinks.classList.toggle("active");
-        })
+document.addEventListener('DOMContentLoaded', () => {
+    const themeToggle = document.getElementById('themeToggle');
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light') {
+        document.body.classList.add('light');
     }
-})
+    if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+            document.body.classList.toggle('light');
+            const mode = document.body.classList.contains('light') ? 'light' : 'dark';
+            localStorage.setItem('theme', mode);
+        });
+    }
+});
 
 function showAlert(message, type = 'success') {
     const alertBox = document.getElementById('alertBox');

--- a/src/main/resources/templates/navigation.html
+++ b/src/main/resources/templates/navigation.html
@@ -8,16 +8,18 @@
 </head>
 <body>
 <div layout:fragment="content">
-    <nav class="navbar">
-        <a class="logo" th:href="@{~/dashboard}">Laxy</a>
-        <button class="menu-toggle" id="menuToggle">&#9776;</button>
-        <ul class="nav-links" id="navLinks">
-            <li><a th:href="@{~/quizzes}">Create Quiz</a></li>
-            <li><a class="signout" th:href="@{~/signout}">Sign Out</a></li>
-        </ul>
-    </nav>
-
-    <div layout:fragment="nav-content"></div>
+    <div class="layout-container">
+        <aside class="sidebar">
+            <a class="logo" th:href="@{~/dashboard}">Laxy</a>
+            <nav class="sidebar-nav">
+                <a th:href="@{~/dashboard}">Dashboard</a>
+                <a th:href="@{~/quizzes}">Create Quiz</a>
+                <button id="themeToggle">Toggle Theme</button>
+                <a class="signout" th:href="@{~/signout}">Sign Out</a>
+            </nav>
+        </aside>
+        <div class="main-content" layout:fragment="nav-content"></div>
+    </div>
 
 </div>
 </body>


### PR DESCRIPTION
## Summary
- add CSS variables and support for light/dark theme
- redesign navigation to a sidebar layout
- update dashboard styles and pages to use new colors
- replace navigation script with theme toggle handling

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6848705eb1ec832ebcd684920bb389f2